### PR TITLE
Updated script to use native MageStack maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
-maintmode.sh usage
+# Magento Scripts
 
-Set domain group root at 'ROOT=' at the start of the file.
+## maintmode.sh
 
-cd /path/to/script
+### Installation
 
-'./maintmode.sh -e' will enable maintenance mode on all stores in this group
-'./maintmode.sh -d' will disable maintenance mode on all stores in this group
+    cp maintmode.sh /usr/local/bin
+    chmod +x /usr/local/bin/maintmode.sh
+
+### Usage
+
+    $(basename $0) [-d|-e]
 
 y OR n to confirm placing all stores in the domain group in to / out of maintenance mode.
+
+### Examples
+
+#### Enable maintenance mode
+
+    cd /microcloud/domains/example
+    maintmode.sh -e
+
+#### Disable maintenance mode
+
+    cd /microcloud/domains/example
+    maintmode.sh -e

--- a/maintmode.sh
+++ b/maintmode.sh
@@ -1,7 +1,37 @@
 #!/bin/bash
-# Enables and disables maintenance mode on all stores in a domain group
+# Enables and disables better maintenance mode on all stores in a domain group
+# See https://www.sonassi.com/help/magestack/maintenance-mode
 
-ROOT=/microcloud/domains/exampl/domains/
+function usage() {
+  cat <<EOF
+$(basename $0) Usage:
+--
+
+    $(basename $0) [-d|-e]
+
+Examples:
+--
+
+> Enable maintenance mode
+
+    cd /microcloud/domains/example
+    $(basename $0) -e
+
+> Disable maintenance mode
+
+    cd /microcloud/domains/example
+    $(basename $0) -e
+
+EOF
+exit 0
+}
+
+CURRENT_DIR=$(pwd)
+
+read DOMAIN_GROUP < <(echo "${CURRENT_DIR}/" | ack-grep "/microcloud/domains/([^/]+)" --output='$1')
+ROOT=/microcloud/domains/$DOMAIN_GROUP/domains
+
+[ ! -d "$ROOT" ] && echo "Error: Domain-group cannot be found" && usage
 
 while getopts ":ed" opt; do
 	case $opt in
@@ -10,13 +40,11 @@ while getopts ":ed" opt; do
 				read -p "This will enable maintenance mode for all stores. Are you sure you wish to continue? (y/n) " yn
 				case $yn in
 					[Yy]* )
-						for D in `find ${ROOT}* -maxdepth 0 -type d`
+						for D in `find ${ROOT}* -maxdepth 1 -mindepth 1 -type d`
 						do
-							if [ -f ${D}/http/_maintenance.flag ];
-							then
-								mv ${D}/http/_maintenance.flag ${D}/http/maintenance.flag
-							else
-								echo "Maintenance flag not found in ${D}/http."
+							if [ ! -f ${D}/.maintenance.on ]; then
+								touch ${D}/.maintenance.on
+								echo "  > ${D}"
 							fi
 						done
 						echo "Maintenance mode enabled." >&2; break;;
@@ -30,13 +58,13 @@ while getopts ":ed" opt; do
 				read -p "This will disable maintenance mode for all stores. Are you sure you wish to continue? (y/n) " yn
 				case $yn in
 					[Yy]* )
-						for D in `find ${ROOT}* -maxdepth 0 -type d`
+						for D in `find ${ROOT}* -maxdepth 1 -mindepth 1 -type d`
 						do
-							if [ -f ${D}/http/maintenance.flag ];
-							then
-								 mv ${D}/http/maintenance.flag ${D}/http/_maintenance.flag
+							if [ -f ${D}/.maintenance.on ]; then
+								 rm ${D}/.maintenance.on
+								 echo "  > ${D}"
 							else
-								echo "Maintenance flag not found in ${D}/http."
+								echo "Maintenance flag not found for ${D}."
 							fi
 						done
 						echo "Maintenance mode disabled." >&2; break;;


### PR DESCRIPTION
A few adjustments to remove the hardcoded path for domain group and use the native MageStack maintenance mode versus the Magento only one.